### PR TITLE
*ns* is always bound, good for attaching options

### DIFF
--- a/dev/scicloj/kindly/gen.clj
+++ b/dev/scicloj/kindly/gen.clj
@@ -67,15 +67,28 @@
   (str "(ns scicloj.kindly.v4.api
   \"See the kind namespace\")
 
-(def ^:dynamic *options*
-  \"Visualization tools take options in the following priority:
+(defn deep-merge
+  \"Recursively merges maps only.\"
+  [& xs]
+  (reduce (fn m [a b]
+            (if (and (map? a) (map? b))
+              (merge-with m a b)
+              b))
+          xs))
 
-  1. options on the metadata of a form or value
-  2. kind specific options found in the `:kinds` map of this dynamic var
-  3. options found in this dynamic var
+(defn set-options!
+  \"Replaces *options* with options\"
+  [options]
+  (alter-meta! *ns* merge {:kindly/options options}))
 
-  See the kindly documentation for valid options.\"
-  nil)
+(defn merge-options!
+  \"Mutates *options* with the deep merge of options\"
+  [options]
+  (alter-meta! *ns* deep-merge {:kindly/options options}))
+
+(defn get-options
+  []
+  (-> (meta *ns*) :kindly/options))
 
 (defn attach-meta-to-value
   [value m]

--- a/src/scicloj/kindly/v4/api.cljc
+++ b/src/scicloj/kindly/v4/api.cljc
@@ -1,15 +1,28 @@
 (ns scicloj.kindly.v4.api
   "See the kind namespace")
 
-(def ^:dynamic *options*
-  "Visualization tools take options in the following priority:
+(defn deep-merge
+  "Recursively merges maps only."
+  [& xs]
+  (reduce (fn m [a b]
+            (if (and (map? a) (map? b))
+              (merge-with m a b)
+              b))
+          xs))
 
-  1. options on the metadata of a form or value
-  2. kind specific options found in the `:kinds` map of this dynamic var
-  3. options found in this dynamic var
+(defn set-options!
+  "Replaces *options* with options"
+  [options]
+  (alter-meta! *ns* merge {:kindly/options options}))
 
-  See the kindly documentation for valid options."
-  nil)
+(defn merge-options!
+  "Mutates *options* with the deep merge of options"
+  [options]
+  (alter-meta! *ns* deep-merge {:kindly/options options}))
+
+(defn get-options
+  []
+  (-> (meta *ns*) :kindly/options))
 
 (defn attach-meta-to-value
   [value m]

--- a/test/scicloj/kindly/v4/api_test.cljc
+++ b/test/scicloj/kindly/v4/api_test.cljc
@@ -1,0 +1,26 @@
+(ns scicloj.kindly.v4.api-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [scicloj.kindly.v4.api :as kindly]))
+
+(deftest deep-merge-test
+  (is (= :foo (kindly/deep-merge :foo))
+      "should not break when given non-maps")
+  (is (= (kindly/deep-merge :foo :bar {:baz 100})
+         {:baz 100})
+      "should return the last item when merging is not possible")
+  (is (= (kindly/deep-merge {:a {:b {:c 10}}}
+                            {:a {:b {:c 11}}})
+         {:a {:b {:c 11}}})
+      "should update deeply nested paths")
+  (is (= (kindly/deep-merge {:a {:b {:c 10}}}
+                            {:a {:b nil}})
+         {:a {:b nil}})
+      "should not merge nil, nil is used as a value for erasure"))
+
+(deftest options-test
+  (kindly/set-options! {:foo "bar"})
+  (is (= "bar" (-> (kindly/get-options) :foo))
+      "setting options should work")
+  (kindly/merge-options! {:foo "baz"})
+  (is (= "baz" (-> (kindly/get-options) :foo))
+      "merging options should work"))


### PR DESCRIPTION
We cannot use *options* dynamic var because it is not bound during normal notebook evaluation.

Instead we can attach :kindly/options to the ns metadata.
This seems to work well with the notion of putting :kindly/options in the metadata as well.
