### PR TITLE
Annotate wrapped values to distinguish them from single-element vectors

### DIFF
--- a/src/scicloj/kindly/v4/api.cljc
+++ b/src/scicloj/kindly/v4/api.cljc
@@ -5,7 +5,9 @@
   [value m]
   (if (instance? clojure.lang.IObj value)
     (vary-meta value merge m)
-    (attach-meta-to-value [value] m)))
+    (attach-meta-to-value
+     [value]
+     (update m :kindly/options assoc :wrapped-value true))))
 
 (defn attach-kind-to-value
   [value kind]

--- a/test/scicloj/kindly/v4/api_test.cljc
+++ b/test/scicloj/kindly/v4/api_test.cljc
@@ -36,6 +36,10 @@
               [:kindly/options :wrapped-value])
       "wrapped values should have annotations in metadata")
 
+(is (not= (meta (kindly/attach-meta-to-value  4  {:kindly/kind :code}))
+          (meta (kindly/attach-meta-to-value [4] {:kindly/kind :code})))
+    "wrapped values should be distinguishable from single-element vectors")
+
   (kindly/set-options! {:foo "bar"})
   (is (= "bar" (-> (kindly/get-options) :foo))
       "setting options should work")

--- a/test/scicloj/kindly/v4/api_test.cljc
+++ b/test/scicloj/kindly/v4/api_test.cljc
@@ -32,6 +32,10 @@
          {:b 2})))
 
 (deftest options-test
+  (is (get-in (meta (kindly/attach-meta-to-value 4 {:kindly/kind :code}))
+              [:kindly/options :wrapped-value])
+      "wrapped values should have annotations in metadata")
+
   (kindly/set-options! {:foo "bar"})
   (is (= "bar" (-> (kindly/get-options) :foo))
       "setting options should work")


### PR DESCRIPTION
I previously reported this issue on Zulip. While a full specification is well outside the scope of this PR, this type of annotation for wrapped values is a necessary component of an unambiguous specification of Kindly values. 

I'm marking this as a draft for now; happy to discuss further before merging.