### PR TITLE
Add kind? predicate

### DIFF
--- a/src/scicloj/kindly/v4/api.cljc
+++ b/src/scicloj/kindly/v4/api.cljc
@@ -76,6 +76,20 @@ is wrapped in a vector first"
   [& args]
   (consider args :kind/test-last))
 
+(defn kind? "Returns true if the value is a Kindly kind of any type." [v]
+  (let [value-meta (meta v)]
+    (cond
+     ;; annotated with metadata
+     (or (contains? value-meta :kind)
+         (contains? value-meta :kindly/kind))
+     true
+     ;; context map
+     (and (map? v)
+          (or (contains? v :kind) (contains? v :kindly/kind))
+          (or (contains? v :value) (contains? v :kindly/value)))
+     true
+     :default false)))
+
 (def known-kinds
   "A set of common visualization requests"
   #{

--- a/test/scicloj/kindly/v4/api_test.cljc
+++ b/test/scicloj/kindly/v4/api_test.cljc
@@ -1,5 +1,5 @@
 (ns scicloj.kindly.v4.api-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is are testing]]
             [scicloj.kindly.v4.api :as kindly]))
 
 (deftest deep-merge-test
@@ -46,3 +46,10 @@
   (kindly/merge-options! {:foo "baz"})
   (is (= "baz" (-> (kindly/get-options) :foo))
       "merging options should work"))
+
+(deftest predicate-test
+  (are [v] (kindly/kind? v)
+   {:value 3 :kind :code}
+   ^{:kind :code} [3]
+   {:value 3 :kindly/kind :kind/code}
+   ^{:kindly/kind :kind/code} [3]))


### PR DESCRIPTION
It would be useful to have a canonical way for kindly, and tools that implement the kindly spec, to answer the question "is this value annotated with a kind?" The answer should be identical across the metadata, wrapped value, and context map ways of displaying a Kindly value. 

Marking this PR as a draft until I understand all of the different ways a kindly value might be annotated.